### PR TITLE
Refactor meta info box

### DIFF
--- a/phovea.js
+++ b/phovea.js
@@ -47,6 +47,10 @@ module.exports = function(registry) {
   registry.push('tacoView', 'BarChart', function () { return System.import('./src/bar_chart'); }, {
     'name': 'BarChart'
   });
+
+  registry.push('tacoView', 'MetaInfoBox', function () { return System.import('./src/meta_info_box'); }, {
+    'name': 'MetaInfoBox'
+  });
   // generator-phovea:end
 };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,7 +70,7 @@ export class App implements IAppView {
       options: {}
     },
     {
-      view: 'Histogram2D',
+      view: 'MetaInfoBox',
       parent: 'selector',
       options: {}
     },
@@ -153,8 +153,6 @@ export class App implements IAppView {
       .then((viewInstances) => {
         // loading and initialization has finished -> hide loading indicator
         this.setBusy(false);
-        d3.select('.placeholderContainer').classed('hidden', false);
-        d3.select('.detailview').classed('hidden', false);
         return this;
       });
 

--- a/src/app_constants.ts
+++ b/src/app_constants.ts
@@ -27,8 +27,7 @@ export class AppConstants {
   static EVENT_DATASET_SELECTED_RIGHT = 'eventDataSetSelectedRight';
   static EVENT_OPEN_DIFF_HEATMAP = 'eventDrawDiffDeatmap';
 
-  static EVENT_OPEN_2D_HISTOGRAM = 'open2DHistogram';
-  static EVENT_CLOSE_2D_HISTOGRAM = 'close2DHistogram';
+  static EVENT_TIME_POINTS_SELECTED = 'eventTimePointsSelected';
 
   static EVENT_TOGGLE_GROUP = 'toggleGroup';
 

--- a/src/detail_view.ts
+++ b/src/detail_view.ts
@@ -73,8 +73,8 @@ class DetailView implements IAppView {
     this.$node.select('#detailViewBtn')
       .on('click', function (e) {
         if(clickedElements !== void 0) {
-          events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, clickedElements[0]);
-          events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, clickedElements[1]);
+          events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, clickedElements[0].item);
+          events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, clickedElements[1].item);
           events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, clickedElements);
           d3.select('.difftitle').classed('hidden', false);
           d3.select('.comparison').classed('hidden', false);

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -78,15 +78,15 @@ class DiffHeatMap implements IAppView {
    private toggleChangeType(changeType) {
 
     if (changeType.type === 'removed') {
-      this.$node.selectAll('.struct-del-color').classed('noColorClass', !changeType.isActive);
+      this.$node.selectAll('.removed-color').classed('noColorClass', !changeType.isActive);
     }
 
     if (changeType.type === 'added') {
-      this.$node.selectAll('.struct-add-color').classed('noColorClass', !changeType.isActive);
+      this.$node.selectAll('.added-color').classed('noColorClass', !changeType.isActive);
     }
 
     if (changeType.type === 'content') {
-      this.$node.selectAll('.taco-ch-cell').classed('noColorClass', !changeType.isActive);
+      this.$node.selectAll('.content-color').classed('noColorClass', !changeType.isActive);
     }
 
     this.$node.selectAll(`div.ratio > .${changeType.type}`).classed('noColorClass', !changeType.isActive);
@@ -165,7 +165,7 @@ class DiffHeatMap implements IAppView {
             .enter()
             .append('div')
             .attr('class', 'taco-added-row')
-            .attr('class', 'struct-add-color')
+            .attr('class', 'added-color')
             .attr('title', (d) => d.id)
             .style('left', 0 + 'px')
             .style('top', function (d) {
@@ -183,7 +183,7 @@ class DiffHeatMap implements IAppView {
             .append('div')
             .attr('title', (d) => d.id)
             .attr('class', 'taco-added-col')
-            .attr('class', 'struct-add-color')
+            .attr('class', 'added-color')
             .style('top', 0 + 'px')
             .style('left', (d) => {
               const x = d.pos;
@@ -199,7 +199,7 @@ class DiffHeatMap implements IAppView {
             .enter()
             .append('div')
             .attr('class', 'taco-del-row')
-            .attr('class', 'struct-del-color')
+            .attr('class', 'removed-color')
             .attr('title', (d) => d.id)
             .style('left', 0 + 'px')
             .style('top', (d) => {
@@ -216,7 +216,7 @@ class DiffHeatMap implements IAppView {
             .enter()
             .append('div')
             .attr('class', 'taco-del-col')
-            .attr('class', 'struct-del-color')
+            .attr('class', 'removed-color')
             .attr('title', (d) => d.id)
             .style('top', 0 + 'px')
             .style('left', (d) => {
@@ -229,10 +229,10 @@ class DiffHeatMap implements IAppView {
       }
 
       if (d.content) {
-        const chCells = root.selectAll('.taco-ch-cell').data(d.content);
+        const chCells = root.selectAll('.content-color').data(d.content);
         chCells.enter()
           .append('div')
-          .attr('class', 'taco-ch-cell')
+          .attr('class', 'content-color')
           .attr('title', (d) => {
             return '(' + d.row + ',' + d.col + ': ' + d.diff_data + ')';
           })

--- a/src/histogram_2d.ts
+++ b/src/histogram_2d.ts
@@ -49,8 +49,7 @@ class Histogram2D implements IAppView {
   constructor(parent: Element, private options: any) {
     this.$node = d3.select(parent)
       .append('div')
-      .classed('histogram_2d', true)
-      .classed('hidden', true);
+      .classed('histogram_2d', true);
   }
 
   /**
@@ -74,7 +73,7 @@ class Histogram2D implements IAppView {
     const windowWidth = $(window).innerWidth();
 
     this.$node
-      .style('width', windowWidth + 'px')
+      //.style('width', windowWidth + 'px')
       .style('height', this.height + 'px');
 
     this.$ratio = this.$node
@@ -82,9 +81,6 @@ class Histogram2D implements IAppView {
       .style('width', this.width + 'px')
       .style('height', this.height + 'px')
       .classed('ratio', true);
-      // .on('click', function () {
-      //   events.fire(AppConstants.EVENT_CLOSE_2D_HISTOGRAM);
-      // });
 
     this.$histogramRows = this.$node
       .append('div')
@@ -105,23 +101,14 @@ class Histogram2D implements IAppView {
    * Attach event handler for broadcasted events
    */
   private attachListener() {
-    // hide when changing the dataset
-    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
-      this.$node.classed('hidden', true);
-    });
+    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, items) => {
+      if(items.length === 2) {
+        this.selectedTables = [items[0].item.desc.id, items[1].item.desc.id];
+        this.updateItems(this.selectedTables);
 
-    events.on(AppConstants.EVENT_CLOSE_2D_HISTOGRAM, () => {
-      this.$node.classed('hidden', true);
-    });
-
-    events.on(AppConstants.EVENT_OPEN_2D_HISTOGRAM, (evt, items) => {
-      d3.selectAll('.placeholder').classed('invisibleClass', true);
-
-      this.selectedTables = [items[0].desc.id, items[1].desc.id];
-      this.posX = ($(window).innerWidth() - 220)/2;
-
-      this.$node.classed('hidden', false);
-      this.updateItems(this.posX, this.selectedTables);
+      } else {
+        this.clearContent();
+      }
     });
 
     events.on(AppConstants.EVENT_SHOW_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
@@ -139,23 +126,14 @@ class Histogram2D implements IAppView {
     this.$node.selectAll(`div.ratio > .${changeType.type}`).classed('noColorClass', !changeType.isActive);
   }
 
-  private updateItems(posX, pair) {
-    this.$ratio
-      .classed('loading', true)
-      .style('left', posX + 'px');
+  private updateItems(pair) {
+    this.$ratio.classed('loading', true);
 
     this.requestData(pair)
       .then((data) => this.showData(data));
 
-    this.$histogramRows
-      .style('left', posX + 'px');
-
-    this.$histogramCols
-      .style('left', posX + 'px');
-
     this.requestDataHistogram(pair)
       .then((histodata) => this.showHistogram(histodata));
-
   }
 
 
@@ -426,6 +404,12 @@ class Histogram2D implements IAppView {
       });
 
     bincontainterCols.exit().remove();
+  }
+
+  private clearContent() {
+    this.$ratio.html('');
+    this.$histogramCols.html('');
+    this.$histogramRows.html('');
   }
 
 }

--- a/src/meta_info_box.ts
+++ b/src/meta_info_box.ts
@@ -1,0 +1,137 @@
+/**
+ * Created by Holger Stitz on 14.03.2017.
+ */
+import * as d3 from 'd3';
+import * as $ from 'jquery';
+import * as events from 'phovea_core/src/event';
+import {AppConstants} from './app_constants';
+import {IAppView} from './app';
+import {getTimeScale} from './util';
+import {get} from 'phovea_core/src/plugin';
+
+/**
+ * Shows a timeline with all available data points for a selected data set
+ */
+class MetaInfoBox implements IAppView {
+
+  private $node;
+  private $leftMetaBox;
+  private $rightMetaBox;
+
+  private items;
+
+  // Width of the timeline div element
+  private totalWidth: number;
+  private boxHeight = 162;
+  private boxWidth = 162;
+
+
+
+  /**
+   * @param parent element on which the infobox element is created
+   * @param options optional options for the infobox element
+   */
+  constructor(parent: Element, private options: any) {
+    this.$node = d3.select(parent).append('div').classed('meta_info_box', true);
+  }
+
+  /**
+   * Initialize the view and return a promise
+   * that is resolved as soon the view is completely initialized.
+   * @returns {Promise<Timeline>}
+   */
+  init() {
+    this.build();
+    this.attachListener();
+
+    // Return the promise directly as long there is no dynamical data to update
+    return Promise.resolve(this);
+  }
+
+  /**
+   * Attach event handler for broadcasted events
+   */
+  private attachListener() {
+    // Call the resize function whenever a resize event occurs
+    d3.select(window).on('resize', () => this.resize());
+
+    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, items) => {
+      if(items.length === 2) {
+        this.updateItems(items);
+      } else {
+        this.clearContent();
+      }
+    });
+
+    events.on(AppConstants.EVENT_DATASET_SELECTED, (evt, items) => {
+      this.clearContent();
+    });
+  }
+
+  /**
+   * Build the basic DOM elements like the svg graph and appends the tooltip div.
+   */
+  private build() {
+    this.$leftMetaBox = this.$node
+      .append('div')
+      //.style('width', this.boxWidth + 'px')
+      .style('height', this.boxHeight + 'px')
+      .classed('leftMetaBox', true);
+
+    this.$rightMetaBox = this.$node
+      .append('div')
+      //.style('width', this.boxWidth + 'px')
+      .style('height', this.boxHeight + 'px')
+      .classed('rightMetaBox', true);
+
+    // wrap view ids from package.json as plugin and load the necessary files
+    get(AppConstants.VIEW, 'Histogram2D')
+      .load()
+      .then((plugin) => {
+        const view = plugin.factory(
+          this.$node.node(), // parent node
+          {} // options
+        );
+        return view.init();
+      });
+  }
+
+  /**
+   * This method updates the graph and the timeline based on the window size and resizes the whole page.
+   */
+  private resize() {
+    this.totalWidth = $(this.$node.node()).width();
+  }
+
+  private updateItems(items) {
+    this.$leftMetaBox.html(this.generateHTML(items[0]));
+    this.$rightMetaBox.html(this.generateHTML(items[1]));
+  }
+
+  private generateHTML(item) {
+    return `
+      <h3>${item.time.format('YYYY')}</h3>
+      <dl>
+        <dt>Rows</dt>
+        <dd>${item.item.dim[0]} ${(item.item.dim[0] === 1) ? item.item.rowtype.name : item.item.rowtype.names}</dd>
+        <dt>Columns</dt>
+        <dd>${item.item.dim[1]} ${(item.item.dim[1] === 1) ? item.item.coltype.name : item.item.coltype.names}</dd>
+      </dl>
+    `;
+  }
+
+  private clearContent() {
+    this.$leftMetaBox.html('');
+    this.$rightMetaBox.html('');
+  }
+}
+
+/**
+ * Factory method to create a new MetaInfoBox instance.
+ * @param parent Element on which the MetaInfoBox is drawn
+ * @param options Parameters for the instance (optional)
+ * @returns {MetaInfoBox}
+ */
+export function create(parent: Element, options: any) {
+  return new MetaInfoBox(parent, options);
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -479,7 +479,7 @@ This aligns the text inside the placeholders.
     flex-direction: column-reverse;
     align-content: flex-end;
     margin-left: -15px; // bar width also defined in bar_chart.ts
-    padding-left: 7.5px; // half the bar width to center on timeline tick
+    transform: translateX(7.5px); // half the bar width to center on timeline tick
   }
 
   .bar {

--- a/src/style.scss
+++ b/src/style.scss
@@ -8,9 +8,6 @@ $no-change-color: #D8D8D8;
 $reorder-color: #decbe4;
 
 $gentle-color: #f0f0f0;
-$gentle-color-dark: #f0f0f0;
-$source-table-color: #f0f0f0;
-$destination-table-color: #f0f0f0;
 
 $boostrapAssetDir: '~phovea_ui/src/assets';
 
@@ -221,63 +218,63 @@ button:active, button.active {
   background-color: $reorder-color;
 }
 
-.placeholderContainer {
+.meta_info_box {
+  margin: 20px 0;
   display: flex;
   flex-direction: row;
   align-items: stretch;
   align-content: stretch;
   justify-content: space-around;
 
-  &>div{
+  & > div{
     width: 33%;
   }
-}
 
-.placeholder {
-  background-color: $gentle-color;
-  //margin: auto;
-  line-height: 162px;
-  border: 1px solid $gentle-color-dark;
-  border-radius: 8px;
-
-  p {
-    display: inline-block;
-    line-height: normal;
-    font-size: 10pt;
-    text-align: center;
-    vertical-align: middle;
+  .leftMetaBox, .rightMetaBox {
+    //margin: auto;
+    line-height: 162px;
+    background: $gentle-color;
+    border: 1px solid $gentle-color;
+    border-radius: 5px;
     padding: 0 10px 0 10px;
+
+    // show placeholder text if boxes are empty
+    &:empty:before {
+      content: 'Select two time points on the timeline to get more information.';
+      width: 100%;
+      text-align: center;
+      display: inline-block;
+      line-height: normal;
+      vertical-align: middle;
+    }
+
+    dt {
+      float: left;
+      clear: left;
+      margin-right: 5px;
+      font-weight: bold;
+    }
+
+    dd {
+      margin-left: 0;
+    }
+  }
+
+  .leftMetaBox {
+    order: 1;
+  }
+
+  .histogram_2d {
+    order: 2;
+    text-align: center;
+  }
+
+  .rightMetaBox {
+    order: 3;
   }
 }
 
-.leftMetaBox  {
-  background: $source-table-color;
-}
 
-.rightMetaBox {
-  background: $destination-table-color;
-}
-
-.leftMetaBox, .rightMetaBox {
-  //margin: auto;
-  line-height: 162px;
-  border: 1px solid $gentle-color-dark;
-  border-radius: 8px;
-
-  p {
-    display: inline-block;
-    line-height: normal;
-    font-size: 10pt;
-    text-align: center;
-    vertical-align: middle;
-    padding: 0 10px 0 10px;
-  }
-}
-
-.histogram_2d {
-  margin-bottom: 140px;
-  margin-top: -162px;       //The height of the 2d histogram ratio
-}
 
 .ratio {
   transition: left .2s ease;
@@ -307,20 +304,16 @@ button:active, button.active {
   border: 1px solid #e6e8e4;
   border-left: 1px solid #000000;
   background: transparent;
-  position:relative;
-  margin-left:15px;
+  position: relative;
+  margin-left: 15px;
 
   &.rotated {
+    position: relative;
     display: block;
     margin-top: -45px;
-    margin-left: 50px;
-    //margin-right: 100px;
+    margin-left: calc(50% - 67px);
     transform: rotate(90deg) scaleY(-1);
     //transform-origin: 0 0;
-
-    //margin-bottom:-125px;
-    //margin-left: 20px;
-    position: relative;
   }
 
   div {
@@ -417,12 +410,12 @@ This class adds a fading effect and hides the element
 
 .filter_bar {
   float: left;
-  margin: 6px 0px 6px 0px;
+  margin: 6px 0 6px 0;
 }
 
 .dataSelector {
   float: left;
-  margin: 6px 20px 6px 60px;
+  margin: 6px 20px 6px 20px;
 }
 
 select.form-control {
@@ -436,9 +429,9 @@ This is the button for the further Details view.
   position: absolute;
   left: 50%;
   transform: translate(-50%, -50px);
-  background-color: $gentle-color;
   color: black;
-  border: 1px solid $gentle-color-dark;
+  background-color: $gentle-color;
+  border: 1px solid $gentle-color;
 }
 
 /**
@@ -453,10 +446,10 @@ heatmaps or diffheatmaps are plotted.
   align-content: stretch;
   justify-content: space-between;
 
-  &>div {
+  & > div {
     width: 33%;
     height: 1000px;
-    border: 1.5px solid $gentle-color-dark;
+    border: 1.5px solid $gentle-color;
   }
 }
 

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -8,7 +8,7 @@ import * as $ from 'jquery';
 import * as events from 'phovea_core/src/event';
 import {AppConstants} from './app_constants';
 import {IAppView} from './app';
-import {getPosXScale, scaleCircles, getTimeScale} from './util';
+import {getTimeScale} from './util';
 
 /**
  * Shows a timeline with all available data points for a selected data set
@@ -17,28 +17,17 @@ class Timeline implements IAppView {
 
   private $node;
   private $svgTimeline;
-  private $placeholder;
-  private $leftMetaBox;
-  private $rightMetaBox;
 
   private items;
 
   // Width of the timeline div element
   private totalWidth: number;
   private timelineWidth = $(window).innerWidth();
-  private timelineHeight = 30;
+  private timelineHeight = 25;
   private toggledElements: boolean;
-  private openHistogram2D;
 
   // Helper variable for the clicking event
   private isClicked: number = 0;
-
-
-  //TODO: CHECK unused variables here!
-  // helper variable for on click event
-  //private open2dHistogram = null;
-  //private colorScale = d3.scale.ordinal().range(['#D8zD8D8', '#67C4A7', '#8DA1CD', '#F08E65']);
-
 
   /**
    * Constructor method for the Timeline class which creates the timeline on the given parent element.
@@ -69,14 +58,12 @@ class Timeline implements IAppView {
    */
   private attachListener() {
     events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, (evt, items) => {
-     this.$leftMetaBox.html('Select the "Source Table" from the timeline in order to see more meta information.');
-     this.$rightMetaBox.html('Select the "Destination Table" from the timeline in order to see more meta information.');
-     this.$placeholder.classed('invisibleClass', false);
      this.updateItems(items);
     });
     // Call the resize function whenever a resize event occurs
     d3.select(window).on('resize', () => this.resize());
   }
+
   /**
    * Build the basic DOM elements like the svg graph and appends the tooltip div.
    */
@@ -85,37 +72,6 @@ class Timeline implements IAppView {
       .append('svg')
       .attr('width', this.timelineWidth)
       .attr('height', this.timelineHeight);
-
-    this.$placeholder = this.$node
-      .append('div')
-      .classed('placeholderContainer', true)
-      .classed('invisibleClass2', true);
-
-    this.$leftMetaBox = this.$placeholder
-      .append('div')
-      .style('width', 162 + 'px')
-      .style('height', 162 + 'px')
-      .classed('leftMetaBox', true)
-      .append('p')
-      .html('Select the "Source Table" from the timeline in order to see more meta information.' );
-
-    this.$placeholder
-      .append('div')
-      .style('width', 162 + 'px')
-      .style('height', 162 + 'px')
-      .classed('placeholder', true)
-      .append('p')
-      .text('Select two time points on the timeline to get more information.' );
-
-    this.$rightMetaBox = this.$placeholder
-      .append('div')
-      .style('width', 162 + 'px')
-      .style('height', 162 + 'px')
-      .classed('rightMetaBox', true)
-      .append('p')
-      .html('Select the "Destination Table" from the timeline in order to see more meta information.' );
-
-
   }
 
   /**
@@ -140,58 +96,6 @@ class Timeline implements IAppView {
     this.$svgTimeline.selectAll('*').remove();
     this.resize();
     this.drawTimeline();
-  }
-
-  /**
-   * This method draws a link from the circle to the heatmap of the source and destination table.
-   * @param x Position of the circle
-   * @param y Position of the circle
-   * @param mode Distinguish between source and destination tables and cricles
-   */
-  private drawLine(x, y, mode) {
-    const that = this;
-    let direction: number = 0;
-    let lineCol: string = 'grey';
-
-    switch (mode) {
-      case 'sourceTable':
-        direction = 100;
-        lineCol = '#E0CBC3';
-        break;
-      case 'destinationTable':
-        direction = this.totalWidth - 100;
-        lineCol = '#BFAEA8';
-        break;
-      default:
-        break;
-    }
-
-    that.$svgTimeline.append('line')
-      .attr('id', 'connectionLine')
-      .style('stroke', lineCol)
-      .style('stroke-width', 3 + 'px')
-      .attr('x1', x)
-      .attr('y1', y)
-      .attr('x2', x )
-      .attr('y2', y + 100);
-
-    that.$svgTimeline.append('line')
-      .attr('id', 'connectionLine')
-      .style('stroke', lineCol)
-      .style('stroke-width', 3 + 'px')
-      .attr('x1', x)
-      .attr('y1', y + 100 )
-      .attr('x2', direction)
-      .attr('y2', y + 100);
-
-    that.$svgTimeline.append('line')
-      .attr('id', 'connectionLine')
-      .style('stroke', lineCol)
-      .style('stroke-width', 3 + 'px')
-      .attr('x1', direction )
-      .attr('y1', y + 100)
-      .attr('x2', direction)
-      .attr('y2', y + 360);
   }
 
 
@@ -222,76 +126,24 @@ class Timeline implements IAppView {
           //Enable the active class only on clicked circle
           d3.select(this).classed('active', true).attr('fill');
 
-          //Fill the meta-information box left
-          if(d.time) {
-            that.$leftMetaBox.html('<strong>Name: </strong>' + d.item.desc.name + '<br>' +
-              '<strong>Date: </strong>' + d.time._d + '<br>' +
-              '<strong>Dimension: </strong>' + d.item.dim[0] + ' X ' + d.item.dim[1] + '<br>' +
-              '<strong>IDTypes: </strong>' +  d.item.desc.coltype + ' X ' + d.item.desc.rowtype + '<br>');
-          } else {
-            that.$leftMetaBox.html('<strong>Name: </strong>' + d.item.desc.name + '<br>' +
-              '<strong>Dimension: </strong>' + d.item.dim[0] + ' X ' + d.item.dim[1] + '<br>' +
-              '<strong>IDTypes: </strong>' +  d.item.desc.coltype + ' X ' + d.item.desc.rowtype + '<br>');
-          }
-
-          // IMPORTANT: Dispatch selected dataset to other views
-          //events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, d.item);
-
-          // Close Histogram only if its rendered and remove also some other elements
-          if (that.openHistogram2D === this.parentNode) {
-            events.fire(AppConstants.EVENT_CLOSE_2D_HISTOGRAM);
-            that.openHistogram2D = null;
-            d3.select('.difftitle').classed('hidden', true);
-            d3.select('.comparison').classed('hidden', true);
-            d3.select('.diffPlaceholder').classed('invisibleClass', false);
-            d3.select('.placeholder').classed('invisibleClass', false);
-            d3.select('#detailViewBtn').attr('disabled', true);
-          }
-
-          clickedElement.push(d.item);
+          clickedElement.push(d);
           that.isClicked = 1;
-          // that.circleX = parseInt(d3.select(this).attr('cx'), 10);
-          // that.circleY = parseInt(d3.select(this).attr('cy'), 10);
-          //
-          // //Remove previous connection line before drawing new one
-          // d3.selectAll('#connectionLine').remove();
-          // that.drawLine(that.circleX, that.circleY, 'sourceTable');
+
+          events.fire(AppConstants.EVENT_TIME_POINTS_SELECTED, []);
+
         } else {
           d3.select(this).classed('active', true).attr('fill');
-          clickedElement.push(d.item);
+          clickedElement.push(d);
 
-          //Fill the meta-information box left
-          if(d.time) {
-            that.$rightMetaBox.html('<strong>Name: </strong>' + d.item.desc.name + '<br>' +
-              '<strong>Date: </strong>' + d.time._d + '<br>' +
-              '<strong>Dimension: </strong>' + d.item.dim[0] + ' X ' + d.item.dim[1] + '<br>' +
-              '<strong>IDTypes: </strong>' +  d.item.desc.coltype + ' X ' + d.item.desc.rowtype + '<br>');
-          } else {
-            that.$rightMetaBox.html('<strong>Name: </strong>' + d.item.desc.name + '<br>' +
-              '<strong>Dimension: </strong>' + d.item.dim[0] + ' X ' + d.item.dim[1] + '<br>' +
-              '<strong>IDTypes: </strong>' +  d.item.desc.coltype + ' X ' + d.item.desc.rowtype + '<br>');
-          }
-
-          // IMPORTANT: Dispatch selected dataset to other views
-          //events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, d.item);
+          // sort elements by time -> [0] = earlier = source; [1] = later = destination
+          const sortedItems = clickedElement.sort((a, b) => d3.ascending(a.time, b.time));
 
           //Only perform events and open Histogram if it is not open already
-          if(that.openHistogram2D !== this.parentNode) {
-            events.fire(AppConstants.EVENT_OPEN_2D_HISTOGRAM, clickedElement);
-            events.fire(AppConstants.EVENT_DATASET_SELECTED, clickedElement);
-
-            that.openHistogram2D = this.parentNode;
-            d3.select('#detailViewBtn').attr('disabled', null);
-          }
-
-          // events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, clickedElement);
+          events.fire(AppConstants.EVENT_TIME_POINTS_SELECTED, sortedItems);
+          d3.select('#detailViewBtn').attr('disabled', null);
 
           that.isClicked = 0;
           clickedElement = [];
-          // that.circleX = parseInt(d3.select(this).attr('cx'), 10);
-          // that.circleY = parseInt(d3.select(this).attr('cy'), 10);
-          //
-          // that.drawLine(that.circleX, that.circleY, 'destinationTable');
         }
       });
   }


### PR DESCRIPTION
Closes #55 and #46.

Selected tables are always sorted ascending (first = earlier, second = later) independent of the order.

![taco_refactored-metainfobox](https://cloud.githubusercontent.com/assets/5851088/23926963/74bf4758-0917-11e7-9982-84c8062dbc4a.png)
