### PR TITLE
Reorder view + improved scaling + resizing + use URL hash

### DIFF
--- a/phovea.js
+++ b/phovea.js
@@ -47,6 +47,10 @@ module.exports = function(registry) {
   registry.push('tacoView', 'MetaInfoBox', function () { return System.import('./src/meta_info_box'); }, {
     'name': 'MetaInfoBox'
   });
+
+  registry.push('tacoView', 'ReorderView', function() { return System.import('./src/reorder_view'); }, {
+    'name': 'Re-Order View'
+  });
   // generator-phovea:end
 };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@
 import * as plugins from 'phovea_core/src/plugin';
 import * as d3 from 'd3';
 import {AppConstants} from './app_constants';
+import * as events from 'phovea_core/src/event';
 
 /**
  * Interface for all TaCo Views
@@ -113,7 +114,14 @@ export class App implements IAppView {
    * @returns {Promise<App>}
    */
   init() {
+    this.attachListener();
     return this.build();
+  }
+
+  private attachListener() {
+    window.addEventListener('resize', () => {
+      events.fire(AppConstants.EVENT_RESIZE);
+    });
   }
 
   /**

--- a/src/app_constants.ts
+++ b/src/app_constants.ts
@@ -25,7 +25,8 @@ export class AppConstants {
   static EVENT_DATASET_SELECTED = 'eventDataSetSelected';
   static EVENT_DATASET_SELECTED_LEFT = 'eventDataSetSelectedLeft';
   static EVENT_DATASET_SELECTED_RIGHT = 'eventDataSetSelectedRight';
-  static EVENT_OPEN_DIFF_HEATMAP = 'eventDrawDiffDeatmap';
+  static EVENT_OPEN_DIFF_HEATMAP = 'eventDrawDiffHeatmap';
+  static EVENT_DIFF_HEATMAP_LOADED = 'eventDiffHeatmapLoaded';
 
   static EVENT_TIME_POINTS_SELECTED = 'eventTimePointsSelected';
 
@@ -34,18 +35,17 @@ export class AppConstants {
   static EVENT_SHOW_CHANGE = 'showChange';
   static EVENT_HIDE_CHANGE = 'hideChange';
 
-
-  /**
-   * Format the date output (see http://momentjs.com/docs/#/displaying/)
-   * @type {string}
-   */
-  static DATE_FORMAT = 'YYYY-MM-DD';
-
   /**
    * Parse the following date formats from strings using moment.js (see http://momentjs.com/docs/#/parsing/)
    * @type {string[]}
    */
   static PARSE_DATE_FORMATS = ['YYYY_MM_DD', 'YYYY-MM-DD', 'YYYY'];
+
+  /**
+   * Initial size of a heatmap cell
+   * @type {number}
+   */
+  static HEATMAP_CELL_SIZE = 5;
 }
 
 export interface IChangeType {

--- a/src/app_constants.ts
+++ b/src/app_constants.ts
@@ -26,6 +26,9 @@ export class AppConstants {
   static EVENT_DATASET_SELECTED_LEFT = 'eventDataSetSelectedLeft';
   static EVENT_DATASET_SELECTED_RIGHT = 'eventDataSetSelectedRight';
   static EVENT_OPEN_DIFF_HEATMAP = 'eventDrawDiffHeatmap';
+
+  static EVENT_OPEN_DETAIL_VIEW = 'eventOpenDetailView';
+
   static EVENT_DIFF_HEATMAP_LOADED = 'eventDiffHeatmapLoaded';
 
   static EVENT_TIME_POINTS_SELECTED = 'eventTimePointsSelected';

--- a/src/app_constants.ts
+++ b/src/app_constants.ts
@@ -46,6 +46,16 @@ export class AppConstants {
    * @type {number}
    */
   static HEATMAP_CELL_SIZE = 5;
+
+  /**
+   * Property for the URL hash
+   * @type {{DATASET: string; TIME_POINTS: string; DETAIL_VIEW: string}}
+   */
+  static HASH_PROPS = {
+    DATASET: 'ds',
+    TIME_POINTS: 'tp',
+    DETAIL_VIEW: 'detail'
+  };
 }
 
 export interface IChangeType {

--- a/src/app_constants.ts
+++ b/src/app_constants.ts
@@ -11,6 +11,7 @@ export class AppConstants {
    */
   static VIEW = 'tacoView';
 
+  static EVENT_RESIZE = 'eventResize';
 
   /**
    * Event that is fired when a data set collection has been selected

--- a/src/bar_chart.ts
+++ b/src/bar_chart.ts
@@ -95,7 +95,7 @@ class BarChart implements IAppView {
    */
   private attachListener() {
     // Call the resize function whenever a resize event occurs
-    //d3.select(window).on('resize', () =>  this.windowResize());
+    //events.on(AppConstants.EVENT_RESIZE, () =>  this.windowResize());
 
     events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, (evt, items) => {
       this.$node.selectAll('*').remove(); // remove, because we have completely new items
@@ -141,7 +141,7 @@ class BarChart implements IAppView {
 
     // Initialize the width
     this.resize();
-    $(window).on('resize', () => this.windowResize(this.items));
+    events.on(AppConstants.EVENT_RESIZE, () => this.windowResize(this.items));
 
     let barPromises;
     const elements = this.$node.selectAll('*');

--- a/src/bar_chart.ts
+++ b/src/bar_chart.ts
@@ -30,7 +30,7 @@ class BarChart implements IAppView {
 
   private barScaling = d3.scale.log()
     .domain([0.1, 100000])
-    .range([0, this.heightBarChart / ChangeTypes.TYPE_ARRAY.length])
+    .range([0, this.heightBarChart / ChangeTypes.TYPE_ARRAY.filter((d) => d !== ChangeTypes.REORDER).length]) // without reorder changes
     .clamp(true);
 
   /**
@@ -168,6 +168,12 @@ class BarChart implements IAppView {
 
     $bars.exit().remove();
 
+    // move the reorder bar into the content change element
+    $parent.selectAll(`.bar.${ChangeTypes.REORDER.type}`)[0]
+      .forEach((d:HTMLElement) => {
+        d.parentElement.querySelector(`.bar.${ChangeTypes.CONTENT.type}`).appendChild(d);
+      });
+
     this.scaleBarsHeight();
   }
 
@@ -189,7 +195,7 @@ class BarChart implements IAppView {
    */
   private getBarData(data, propertyName) {
     return ChangeTypes.TYPE_ARRAY
-    //.filter((d) => d.isActive === true)
+      //.filter((d) => d.isActive === true)
       .map((d) => {
         return {
           type: d.type,

--- a/src/bar_chart.ts
+++ b/src/bar_chart.ts
@@ -63,21 +63,12 @@ class BarChart implements IAppView {
    * @returns {Promise<BarChart>}
    */
   init() {
-    this.build();
+    this.resize();
     this.attachListener();
 
     // Return the promise directly as long there is no dynamical data to update
     return Promise.resolve(this);
   }
-
-
-  /**
-   * Build the basic DOM elements and binds the change function
-   */
-  private build() {
-    //
-  }
-
 
   /**
    * This method is called when the window or chart gets resized.
@@ -85,7 +76,6 @@ class BarChart implements IAppView {
    */
   private resize() {
     this.totalWidth = $(this.$node.node()).width();
-
     this.$node.style('width', this.totalWidth);
   }
 
@@ -95,10 +85,13 @@ class BarChart implements IAppView {
    */
   private attachListener() {
     // Call the resize function whenever a resize event occurs
-    //events.on(AppConstants.EVENT_RESIZE, () =>  this.windowResize());
+    events.on(AppConstants.EVENT_RESIZE, () => {
+      this.resize();
+      this.updateItems(this.items);
+    });
 
     events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, (evt, items) => {
-      this.$node.selectAll('*').remove(); // remove, because we have completely new items
+      this.items = items;
       this.updateItems(items);
     });
 
@@ -112,129 +105,62 @@ class BarChart implements IAppView {
   }
 
   /**
-   * Create Array with index numbers for the positioning of the bars without the time element
-   * @param items are the elements that are displayed
-   * @param width is the new width of the chart
-   */
-  private generateIndexArray(items, width) {
-    this.items = items;
-
-    this.index = d3.range(1, items.length);
-    const circleScaling = scaleCircles(width, this.items.length);
-
-    for (const i in this.index) {
-      if (this.index.hasOwnProperty(i)) {
-        this.leftValue.push((this.index[i] * circleScaling));
-      }
-    }
-  }
-
-  /**
    * This method updates the chart upon changing the data or if new data arrives.
    * @param items which are used for the chart
    */
   private updateItems(items) {
-    this.items = items;
-    const width = $(window).innerWidth();
-    // Generate the array with positioning numbers
-    this.generateIndexArray(this.items, width);
+    const that = this;
 
-    // Initialize the width
-    this.resize();
-    events.on(AppConstants.EVENT_RESIZE, () => this.windowResize(this.items));
+    // duplicate the first entry to show a bar for the first timestep
+    items.unshift(items[0]);
 
-    let barPromises;
-    const elements = this.$node.selectAll('*');
+    const pairs = d3.pairs(items);
+    const posXScale = getTimeScale(items, this.totalWidth);
 
-    // draw the first bar manually showing only additions
-    const firstSize = this.items[0].item.desc.size;
-    this.drawBars({counts: {a_counts: firstSize[0] * firstSize[1]}, ratios: {a_ratio: 1.0}}, [this.items[0], this.items[0]], 10, this.totalWidth);
+    const $bars = this.$node.selectAll('div.bars')
+      .data(pairs, (d) => d[1].item.desc.id);
 
-    if (elements.empty() === false) {
-      barPromises = this.requestData(this.totalWidth, this.leftValue);
-
-    } else {
-      barPromises = this.requestData(this.totalWidth, this.leftValue);
-      this.leftValue = [];
-    }
-
-    // Check if all bars have been loaded
-    Promise.all(barPromises).then((bars) => {
-      console.log('finished loading of all bars');
-    });
-  }
-
-
-  /**
-   * This event happens upon resizing the window and it calculates the new array
-   * and the index as well as the positioning.
-   * @param items which are displayed in the chart
-   */
-  private windowResize(items) {
-    this.items = items;
-    const width = $(window).innerWidth();
-
-    this.generateIndexArray(this.items, width);
-
-    const elements = d3.selectAll('.bars');
-    if (elements.empty() === false) {
-      this.requestData(width, this.leftValue);
-      elements.remove();
-    }
-    this.leftValue = [];
-  }
-
-  /**
-   * TODO: Documentation
-   * @param totalWidth
-   * @param leftValue
-   * @returns {Promise<TResult>[]}
-   */
-  private requestData(totalWidth, leftValue) {
-    return d3.pairs(this.items)
-      .map((pair) => {
+    $bars.enter().append('div')
+      .classed('bars', true)
+      .style('width', this.widthBarChart + 'px')
+      .style('height', this.heightBarChart + 'px')
+      .on('click', (d) => {
+        selectTimePoint(d[1]);
+      })
+      .each(function(pair, i) {
         const ids = pair.map((d: any) => d.item.desc.id);
-        return Promise.all([BarChart.getJSON(ids), pair, ids])
-          .then((args) => {
-            const json = args[0];
-            const pair = args[1];
-            this.drawBars(json, pair, leftValue.shift(), totalWidth);
+        return BarChart.getJSON(ids)
+          .then((json) => {
+            // shift no-change to additions for first bar
+            if(i === 0) {
+              json.counts.a_counts = json.counts.no_counts;
+              json.counts.no_counts = 0;
+              json.ratios.a_ratio = json.ratios.no_a_ratio;
+              json.ratios.no_a_ratio = 0;
+            }
+
+            that.drawBar(d3.select(this), json, pair);
           });
       });
+
+    $bars.style('left', (d) => posXScale(d[1].time.toDate()) + 'px');
+
+    $bars.exit().remove();
   }
 
   /**
    * This method draws the bars on the timeline or above the timeline.
    * TODO: Documentation
+   * @param $parent
    * @param data
    * @param pair
-   * @param circleScale
-   * @param totalWidth
    */
-  private drawBars(data, pair, circleScale:number, totalWidth:number) {
-    const posXScale = getTimeScale(this.items, totalWidth);
-
+  private drawBar($parent, data, pair) {
     //const barData = this.getBarData(data.ratios, 'ratioName');
     const barData = this.getBarData(data.counts, 'countName');
 
-    const currId = pair.map((d) => d.item.desc.id).join('_');
-    let $barsGroup = this.$node.select(`[data-id="${currId}"]`);
-
-    // create bar group for id if not exists
-    if($barsGroup.node() === null) {
-      $barsGroup = this.$node.append('div')
-        .classed('bars', true)
-        .attr('data-id', currId)
-        .style('width', this.widthBarChart + 'px')
-        .style('height', this.heightBarChart + 'px')
-        .style('left', ((pair[1].time) ? posXScale(pair[1].time.toDate()) : circleScale) + 'px')
-        .on('click', () => {
-          selectTimePoint(pair[1]);
-        });
-    }
-
     //individual bars in the bar group div
-    const $bars = $barsGroup.selectAll('div.bar').data(barData);
+    const $bars = $parent.selectAll('div.bar').data(barData);
     $bars.enter().append('div');
 
     $bars
@@ -256,7 +182,6 @@ class BarChart implements IAppView {
         return 0; // shrink bar to 0 if change is not active
       });
   }
-
 
   /**
    *

--- a/src/bar_chart.ts
+++ b/src/bar_chart.ts
@@ -8,7 +8,7 @@ import * as $ from 'jquery';
 import * as events from 'phovea_core/src/event';
 import {AppConstants, ChangeTypes, IChangeType} from './app_constants';
 import {IAppView} from './app';
-import {scaleCircles, getTimeScale, selectTimePoint} from './util';
+import {getTimeScale, selectTimePoint} from './util';
 
 /**
  * This class adds a bar chart, that shows bars with click functionality,
@@ -20,8 +20,6 @@ class BarChart implements IAppView {
   private items;
 
   private totalWidth: number = 0;
-  private index = [];
-  private leftValue = [];
 
   // Width of the bars in the bar chart
   private widthBar: number = 15;

--- a/src/data_set_selector.ts
+++ b/src/data_set_selector.ts
@@ -125,9 +125,10 @@ class DataProvider {
    */
   load() {
     return data
-      .list((d) => {
-       return d.desc.type === 'matrix' && (<IMatrixDataDescription<IValueTypeDesc>>d.desc).value.type === VALUE_TYPE_REAL; // return numerical matrices only
-      })
+      //.list((d) => {
+      //  return d.desc.type === 'matrix' && (<IMatrixDataDescription<IValueTypeDesc>>d.desc).value.type === VALUE_TYPE_REAL; // return numerical matrices only
+      //})
+      .list({'type': 'matrix'}) // use server-side filtering
       .then((list: INumericalMatrix[]) => {
         const olympicsData = this.prepareOlympicsData(list);
         const tcgaData = this.prepareTCGAData(list);

--- a/src/data_set_selector.ts
+++ b/src/data_set_selector.ts
@@ -144,7 +144,7 @@ class DataProvider {
       .entries(matrices.filter((d) => dateRegex.test(d.desc.fqname) === true))
       .map((d) => {
         d.values = d.values.map((e) => {
-          e.timeFormat = {d3: '%Y-%m-%d', moment: 'YYYY-MM-DD'};
+          e.timeFormat = {d3: '%Y-%m-%d', moment: 'YYYY-MM-DD', momentIsSame: 'day'};
           e.item = e.values[0]; // shortcut reference
 
           const matches = e.key.match(dateRegex);
@@ -168,7 +168,7 @@ class DataProvider {
       .reduce((prev, curr) => prev.concat(curr), [])
       .map((d) => {
         d.values = d.values.map((e) => {
-          e.timeFormat = {d3: '%Y', moment: 'YYYY'};
+          e.timeFormat = {d3: '%Y', moment: 'YYYY', momentIsSame: 'year'};
           e.item = e.values[0]; // shortcut reference
 
           const matches = e.key.match(/(\d)\w+/g);

--- a/src/detail_view.ts
+++ b/src/detail_view.ts
@@ -1,16 +1,11 @@
 /**
- * Created by cniederer on 01.03.17.
- */
-/**
  * Created by cniederer on 20.01.17.
  */
 
-//import * as events from 'phovea_core/src/event';
 import {IAppView} from './app';
 import * as d3 from 'd3';
 import * as events from 'phovea_core/src/event';
 import {AppConstants} from './app_constants';
-import * as ajax from 'phovea_core/src/ajax';
 
 class DetailView implements IAppView {
   private $node;

--- a/src/detail_view.ts
+++ b/src/detail_view.ts
@@ -6,6 +6,7 @@ import {IAppView} from './app';
 import * as d3 from 'd3';
 import * as events from 'phovea_core/src/event';
 import {AppConstants} from './app_constants';
+import {hash} from 'phovea_core/src';
 
 class DetailView implements IAppView {
   private $node;
@@ -42,6 +43,9 @@ class DetailView implements IAppView {
         if(clickedElements.length !== 2) {
           return;
         }
+
+        hash.setInt(AppConstants.HASH_PROPS.DETAIL_VIEW, 1);
+
         events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, clickedElements[0].item);
         events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, clickedElements[1].item);
         events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, clickedElements.map((d) => d.item));

--- a/src/detail_view.ts
+++ b/src/detail_view.ts
@@ -31,6 +31,10 @@ class DetailView implements IAppView {
   }
 
   private attachListener() {
+    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
+      this.$node.select('button').attr('disabled', 'disabled');
+    });
+
     events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, clickedElement) => {
       this.openEvents(clickedElement);
     });

--- a/src/detail_view.ts
+++ b/src/detail_view.ts
@@ -59,9 +59,9 @@ class DetailView implements IAppView {
 
     hash.setInt(AppConstants.HASH_PROPS.DETAIL_VIEW, 1);
 
+    events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, selection.map((d) => d.item));
     events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, selection[0].item);
     events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, selection[1].item);
-    events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, selection.map((d) => d.item));
     this.$node.select('button').attr('disabled', 'disabled');
   }
 }

--- a/src/detail_view.ts
+++ b/src/detail_view.ts
@@ -35,26 +35,34 @@ class DetailView implements IAppView {
       this.$node.select('button').attr('disabled', 'disabled');
     });
 
-    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, clickedElement) => {
-      this.openEvents(clickedElement);
+    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, items) => {
+      this.openEvents(items);
+    });
+
+    events.on(AppConstants.EVENT_OPEN_DETAIL_VIEW, (evt, items) => {
+      this.loadDetailView(items);
     });
   }
 
-  private openEvents (clickedElements) {
+  private openEvents (items) {
     this.$node.select('button')
-      .attr('disabled', (clickedElements.length === 2) ? null : 'disabled')
+      .attr('disabled', (items.length === 2) ? null : 'disabled')
       .on('click', (e) => {
-        if(clickedElements.length !== 2) {
-          return;
-        }
-
-        hash.setInt(AppConstants.HASH_PROPS.DETAIL_VIEW, 1);
-
-        events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, clickedElements[0].item);
-        events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, clickedElements[1].item);
-        events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, clickedElements.map((d) => d.item));
-        this.$node.select('button').attr('disabled', 'disabled');
+        this.loadDetailView(items);
       });
+  }
+
+  private loadDetailView(selection) {
+    if(selection.length !== 2) {
+      return;
+    }
+
+    hash.setInt(AppConstants.HASH_PROPS.DETAIL_VIEW, 1);
+
+    events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, selection[0].item);
+    events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, selection[1].item);
+    events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, selection.map((d) => d.item));
+    this.$node.select('button').attr('disabled', 'disabled');
   }
 }
 

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -7,6 +7,7 @@ import * as d3 from 'd3';
 import * as events from 'phovea_core/src/event';
 import * as ajax from 'phovea_core/src/ajax';
 import {AppConstants, IChangeType, ChangeTypes} from './app_constants';
+import {get} from 'phovea_core/src/plugin';
 
 
 /**
@@ -17,9 +18,7 @@ class DiffHeatMap implements IAppView {
   //main div
   private $node;
 
-  private items;
-
-  private selectedTables = [];
+  private initialSize = AppConstants.HEATMAP_CELL_SIZE;
 
   private colorLow = '#d8b365';
   private colorMed = 'white';
@@ -42,213 +41,179 @@ class DiffHeatMap implements IAppView {
    * @returns {Promise<HeatMap>}
    */
   init() {
+    this.build();
     this.attachListener();
     // return the promise directly as long there is no dynamical data to update
     return Promise.resolve(this);
   }
 
-
+  private build() {
+    // wrap view ids from package.json as plugin and load the necessary files
+    get(AppConstants.VIEW, 'ReorderView')
+      .load()
+      .then((plugin) => {
+        const view = plugin.factory(
+          this.$node.node(), // parent node
+          {} // options
+        );
+        return view.init();
+      });
+  }
 
   /**
    * Attach event handler for broadcasted events
    */
   private attachListener() {
     //attach event listener
-    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, (evt, items) => this.updateItems(items));
-
     events.on(AppConstants.EVENT_OPEN_DIFF_HEATMAP, (evt, items) => {
-      //console.log('übergebene items', items[0], items[1]);
-      this.selectedTables = items;
-      //console.log('selected Tables', this.selectedTables);
+      if(items.length !== 2) {
+        return;
+      }
+
       this.$node.selectAll('div').remove();
-      this.diffHeatmap();
-      //console.log('selectedTables -- NOW', this.selectedTables);
+
+      const idsSelectedTable = items.map((d:any) => d.desc.id);
+      DiffHeatMap.getJSON(idsSelectedTable)
+        .then((data) => {
+          this.drawDiffHeatmap(data);
+          events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, items, data);
+        });
     });
 
     events.on(AppConstants.EVENT_SHOW_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
     events.on(AppConstants.EVENT_HIDE_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
-
   }
 
-   private toggleChangeType(changeType) {
+  private toggleChangeType(changeType:IChangeType) {
+    switch(changeType.type) {
+      case ChangeTypes.REMOVED.type:
+        this.$node.selectAll('.removed-color').classed('noColorClass', !changeType.isActive);
+        break;
 
-    if (changeType.type === 'removed') {
-      this.$node.selectAll('.removed-color').classed('noColorClass', !changeType.isActive);
-    }
+      case ChangeTypes.ADDED.type:
+        this.$node.selectAll('.added-color').classed('noColorClass', !changeType.isActive);
+        break;
 
-    if (changeType.type === 'added') {
-      this.$node.selectAll('.added-color').classed('noColorClass', !changeType.isActive);
-    }
-
-    if (changeType.type === 'content') {
-      this.$node.selectAll('.content-color').classed('noColorClass', !changeType.isActive);
+      case ChangeTypes.CONTENT.type:
+        this.$node.selectAll('.added-color').classed('noColorClass', !changeType.isActive);
+        break;
     }
 
     this.$node.selectAll(`div.ratio > .${changeType.type}`).classed('noColorClass', !changeType.isActive);
   }
 
-
-
-  private updateItems(items) {
-    this.items = items;
-  }
-
-  private diffHeatmap() {
-    const dataPromise = this.requestData();
-    Promise.all(dataPromise).then((data) => {
-      this.drawDiffHeatmap(data);
-    });
-    this.selectedTables = [];
-  }
-
-  private requestData() {
-    //console.log('seletedTable -- Request data', this.selectedTables);
-    return d3.pairs(this.selectedTables)
-      .map((pair) => {
-        //console.log('pair', pair);
-        // const ids = pair.map((d:any) => d.item.desc.id);
-        //console.log('ids', ids);
-        const idsSelectedTable = pair.map((d:any) => d.desc.id);
-        //console.log('ids', idsSelectedTable);
-        // return Promise.all([ajax.getAPIJSON(DiffHeatMap.getURL(ids)), pair, ids])
-        return DiffHeatMap.getJSON(idsSelectedTable)
-          .then((args) => {
-            // console.log('args', args);
-            //this.drawDiffHeatmap(args);
-            return args;
-          });
-      });
-  }
-
   private drawDiffHeatmap(data) {
-    const that = this;
     const colorScale = d3.scale.linear<string>()
       .domain([-1, 0, 1])
       .range([this.colorLow, this.colorMed, this.colorHigh])
       .clamp(true);
 
-    const diffParent = that.$node.node();
     const borderWidth = 2;
-
-    const gridHeight = diffParent.getBoundingClientRect().height - 3;
-    const gridWidth = diffParent.getBoundingClientRect().width;
-
-    const height = gridHeight - borderWidth;
-    const width = gridWidth - borderWidth;
-
-    let h = 0;
-    let w = 0;
+    const width = this.initialSize * data.union.uc_ids.length;
+    const height = this.initialSize * data.union.ur_ids.length;
 
     const root = this.$node.append('div')
       .attr('class', 'taco-table')
       .style('width', (width + borderWidth) + 'px')
       .style('height', (height + borderWidth) + 'px')
-
       .style('background-color', 'white')
       .style('transform-origin', '0 0');
 
-    //visualizing the diff
-    data.forEach(function (d) {
-      h = height / d.union.ur_ids.length;
-      //width of each column in the heatmap
-      w = width / d.union.uc_ids.length;
+    if (data.structure) {
 
-      if (d.structure) {
-
-        if(d.structure.added_rows) {
-          const addedRows = root.selectAll('.taco-added-row')
-            .data(d.structure.added_rows)
-            .enter()
-            .append('div')
-            .attr('class', 'taco-added-row')
-            .attr('class', 'added-color')
-            .attr('title', (d) => d.id)
-            .style('left', 0 + 'px')
-            .style('top', function (d) {
-              const y = d.pos;
-              return (y !== -1 ? y * h : null) + 'px';
-            })
-            .style('width', width + 'px')
-            .style('height', h + 'px');
-        }
-
-        if(d.structure.added_cols) {
-          const addedCols = root.selectAll('.taco-added-col')
-            .data(d.structure.added_cols)
-            .enter()
-            .append('div')
-            .attr('title', (d) => d.id)
-            .attr('class', 'taco-added-col')
-            .attr('class', 'added-color')
-            .style('top', 0 + 'px')
-            .style('left', (d) => {
-              const x = d.pos;
-              return (x !== -1 ? x * w : null) + 'px';
-            })
-            .style('width', w + 'px')
-            .style('height', height + 'px');
-        }
-
-        if(d.structure.deleted_rows) {
-          const deletedRows = root.selectAll('.taco-del-row')
-            .data(d.structure.deleted_rows)
-            .enter()
-            .append('div')
-            .attr('class', 'taco-del-row')
-            .attr('class', 'removed-color')
-            .attr('title', (d) => d.id)
-            .style('left', 0 + 'px')
-            .style('top', (d) => {
-              const y = d.pos;
-              return (y !== -1 ? y * h : null) + 'px';
-            })
-            .style('width', width + 'px')
-            .style('height', h + 'px');
-        }
-
-        if(d.structure.deleted_cols) {
-          const deletedCols = root.selectAll('.taco-del-col')
-            .data(d.structure.deleted_cols)
-            .enter()
-            .append('div')
-            .attr('class', 'taco-del-col')
-            .attr('class', 'removed-color')
-            .attr('title', (d) => d.id)
-            .style('top', 0 + 'px')
-            .style('left', (d) => {
-              const x = d.pos;
-              return (x !== -1 ? x * w : null) + 'px';
-            })
-            .style('width', w + 'px')
-            .style('height', height + 'px');
-        }
-      }
-
-      if (d.content) {
-        const chCells = root.selectAll('.content-color').data(d.content);
-        chCells.enter()
+      if(data.structure.added_rows) {
+        const addedRows = root.selectAll('.taco-added-row')
+          .data(data.structure.added_rows)
+          .enter()
           .append('div')
-          .attr('class', 'content-color')
-          .attr('title', (d) => {
-            return '(' + d.row + ',' + d.col + ': ' + d.diff_data + ')';
+          .attr('class', 'taco-added-row')
+          .attr('class', 'added-color')
+          .attr('title', (d) => d.id)
+          .style('left', 0 + 'px')
+          .style('top', function (d) {
+            const y = d.pos;
+            return (y !== -1 ? y * this.cellHeight : null) + 'px';
           })
-          .style('top', (d) => {
-            //var y = that.row_ids.indexOf(d.row);
-            const y = d.rpos;
-            return (y !== -1 ? y * h : null) + 'px';
-          })
-          .style('left', (d) => {
-            //var x = that.col_ids.indexOf(d.col);
-            const x = d.cpos;
-            return (x !== -1 ? x * w : null) + 'px';
-          })
-          .style('width', w + 'px')
-          .style('height', h + 'px')
-          .style('background-color', 'red')
-          .style('z-index', 1000)
-          .style('background-color', (d) => colorScale(d.diff_data));
+          .style('width', width + 'px')
+          .style('height', this.initialSize + 'px');
       }
-    });
+
+      if(data.structure.added_cols) {
+        const addedCols = root.selectAll('.taco-added-col')
+          .data(data.structure.added_cols)
+          .enter()
+          .append('div')
+          .attr('title', (d) => d.id)
+          .attr('class', 'taco-added-col')
+          .attr('class', 'added-color')
+          .style('top', 0 + 'px')
+          .style('left', (d) => {
+            const x = d.pos;
+            return (x !== -1 ? x * this.initialSize : null) + 'px';
+          })
+          .style('width', this.initialSize + 'px')
+          .style('height', height + 'px');
+      }
+
+      if(data.structure.deleted_rows) {
+        const deletedRows = root.selectAll('.taco-del-row')
+          .data(data.structure.deleted_rows)
+          .enter()
+          .append('div')
+          .attr('class', 'taco-del-row')
+          .attr('class', 'removed-color')
+          .attr('title', (d) => d.id)
+          .style('left', 0 + 'px')
+          .style('top', (d) => {
+            const y = d.pos;
+            return (y !== -1 ? y * this.initialSize : null) + 'px';
+          })
+          .style('width', width + 'px')
+          .style('height', this.initialSize + 'px');
+      }
+
+      if(data.structure.deleted_cols) {
+        const deletedCols = root.selectAll('.taco-del-col')
+          .data(data.structure.deleted_cols)
+          .enter()
+          .append('div')
+          .attr('class', 'taco-del-col')
+          .attr('class', 'removed-color')
+          .attr('title', (d) => d.id)
+          .style('top', 0 + 'px')
+          .style('left', (d) => {
+            const x = d.pos;
+            return (x !== -1 ? x * this.initialSize : null) + 'px';
+          })
+          .style('width', this.initialSize + 'px')
+          .style('height', height + 'px');
+      }
+    }
+
+    if (data.content) {
+      const chCells = root.selectAll('.content-color').data(data.content);
+      chCells.enter()
+        .append('div')
+        .attr('class', 'content-color')
+        .attr('title', (d) => {
+          return '(' + d.row + ',' + d.col + ': ' + d.diff_data + ')';
+        })
+        .style('top', (d) => {
+          //var y = that.row_ids.indexOf(d.row);
+          const y = d.rpos;
+          return (y !== -1 ? y * this.initialSize : null) + 'px';
+        })
+        .style('left', (d) => {
+          //var x = that.col_ids.indexOf(d.col);
+          const x = d.cpos;
+          return (x !== -1 ? x * this.initialSize : null) + 'px';
+        })
+        .style('width', this.initialSize + 'px')
+        .style('height', this.initialSize + 'px')
+        .style('background-color', 'red')
+        .style('z-index', 1000)
+        .style('background-color', (d) => colorScale(d.diff_data));
+    }
   }
 }
 

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -18,11 +18,14 @@ class DiffHeatMap implements IAppView {
   //main div
   private $node;
 
-  private initialSize = AppConstants.HEATMAP_CELL_SIZE;
-
   private colorLow = '#d8b365';
   private colorMed = 'white';
   private colorHigh = '#8da0cb';
+
+  private borderWidth = 2;
+  private margin = 2 * 50;
+
+  private scaleFactor = 1;
 
   private static getJSON(pair) {
     const operations = ChangeTypes.forURL();
@@ -84,7 +87,7 @@ class DiffHeatMap implements IAppView {
       DiffHeatMap.getJSON(idsSelectedTable)
         .then((data) => {
           this.drawDiffHeatmap(data);
-          events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, items, data);
+          events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, items, data, this.scaleFactor);
         });
     });
 
@@ -116,16 +119,23 @@ class DiffHeatMap implements IAppView {
       .range([this.colorLow, this.colorMed, this.colorHigh])
       .clamp(true);
 
-    const borderWidth = 2;
-    const width = this.initialSize * data.union.uc_ids.length;
-    const height = this.initialSize * data.union.ur_ids.length;
+    const dataWidth = AppConstants.HEATMAP_CELL_SIZE * data.union.uc_ids.length;
+    const dataHeight = AppConstants.HEATMAP_CELL_SIZE * data.union.ur_ids.length;
+
+    this.scaleFactor = (this.$node.property('clientWidth') - this.margin) / dataWidth;
+
+    const cellSize = AppConstants.HEATMAP_CELL_SIZE * this.scaleFactor;
+    const width = dataWidth * this.scaleFactor;
+    const height = dataHeight * this.scaleFactor;
 
     const root = this.$node.append('div')
       .attr('class', 'taco-table')
-      //.style('width', (width + borderWidth) + 'px')
-      .style('height', (height + borderWidth) + 'px')
-      .style('background-color', 'white')
-      .style('transform-origin', '0 0');
+      .style('width', (width + this.borderWidth) + 'px')
+      .style('height', (height + this.borderWidth) + 'px')
+      .append('div')
+      //.style('transform-origin', '0 0')
+      //.style('transform', `scale(${scaleFactor})`)
+      .classed('transform', true);
 
     if (data.structure) {
 
@@ -140,10 +150,10 @@ class DiffHeatMap implements IAppView {
           .style('left', 0 + 'px')
           .style('top', function (d) {
             const y = d.pos;
-            return (y !== -1 ? y * this.cellHeight : null) + 'px';
+            return (y !== -1 ? y * cellSize : null) + 'px';
           })
           .style('width', width + 'px')
-          .style('height', this.initialSize + 'px');
+          .style('height', cellSize + 'px');
       }
 
       if(data.structure.added_cols) {
@@ -157,9 +167,9 @@ class DiffHeatMap implements IAppView {
           .style('top', 0 + 'px')
           .style('left', (d) => {
             const x = d.pos;
-            return (x !== -1 ? x * this.initialSize : null) + 'px';
+            return (x !== -1 ? x * cellSize : null) + 'px';
           })
-          .style('width', this.initialSize + 'px')
+          .style('width', cellSize + 'px')
           .style('height', height + 'px');
       }
 
@@ -174,10 +184,10 @@ class DiffHeatMap implements IAppView {
           .style('left', 0 + 'px')
           .style('top', (d) => {
             const y = d.pos;
-            return (y !== -1 ? y * this.initialSize : null) + 'px';
+            return (y !== -1 ? y * cellSize : null) + 'px';
           })
           .style('width', width + 'px')
-          .style('height', this.initialSize + 'px');
+          .style('height', cellSize + 'px');
       }
 
       if(data.structure.deleted_cols) {
@@ -191,9 +201,9 @@ class DiffHeatMap implements IAppView {
           .style('top', 0 + 'px')
           .style('left', (d) => {
             const x = d.pos;
-            return (x !== -1 ? x * this.initialSize : null) + 'px';
+            return (x !== -1 ? x * cellSize : null) + 'px';
           })
-          .style('width', this.initialSize + 'px')
+          .style('width', cellSize + 'px')
           .style('height', height + 'px');
       }
     }
@@ -209,15 +219,15 @@ class DiffHeatMap implements IAppView {
         .style('top', (d) => {
           //var y = that.row_ids.indexOf(d.row);
           const y = d.rpos;
-          return (y !== -1 ? y * this.initialSize : null) + 'px';
+          return (y !== -1 ? y * cellSize : null) + 'px';
         })
         .style('left', (d) => {
           //var x = that.col_ids.indexOf(d.col);
           const x = d.cpos;
-          return (x !== -1 ? x * this.initialSize : null) + 'px';
+          return (x !== -1 ? x * cellSize : null) + 'px';
         })
-        .style('width', this.initialSize + 'px')
-        .style('height', this.initialSize + 'px')
+        .style('width', cellSize + 'px')
+        .style('height', cellSize + 'px')
         .style('background-color', 'red')
         .style('z-index', 1000)
         .style('background-color', (d) => colorScale(d.diff_data));

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -64,6 +64,14 @@ class DiffHeatMap implements IAppView {
    * Attach event handler for broadcasted events
    */
   private attachListener() {
+    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
+      this.clearContent();
+    });
+
+    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, () => {
+      this.clearContent();
+    });
+
     //attach event listener
     events.on(AppConstants.EVENT_OPEN_DIFF_HEATMAP, (evt, items) => {
       if(items.length !== 2) {
@@ -114,7 +122,7 @@ class DiffHeatMap implements IAppView {
 
     const root = this.$node.append('div')
       .attr('class', 'taco-table')
-      .style('width', (width + borderWidth) + 'px')
+      //.style('width', (width + borderWidth) + 'px')
       .style('height', (height + borderWidth) + 'px')
       .style('background-color', 'white')
       .style('transform-origin', '0 0');
@@ -214,6 +222,10 @@ class DiffHeatMap implements IAppView {
         .style('z-index', 1000)
         .style('background-color', (d) => colorScale(d.diff_data));
     }
+  }
+
+  private clearContent() {
+    this.$node.select('.taco-table').remove();
   }
 }
 

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -100,8 +100,7 @@ class DiffHeatMap implements IAppView {
     events.on(AppConstants.EVENT_SHOW_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
     events.on(AppConstants.EVENT_HIDE_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
 
-    // Call the resize function whenever a resize event occurs
-    d3.select(window).on('resize', () => {
+    events.on(AppConstants.EVENT_RESIZE, () => {
       this.drawDiffHeatmap(this.data);
       events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, this.selectedTables, this.data, this.scaleFactor);
     });

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -20,6 +20,7 @@ class DiffHeatMap implements IAppView {
 
   // cached data
   private data;
+  private selectedTables;
 
   private colorLow = '#d8b365';
   private colorMed = 'white';
@@ -90,8 +91,9 @@ class DiffHeatMap implements IAppView {
       DiffHeatMap.getJSON(idsSelectedTable)
         .then((data) => {
           this.data = data;
+          this.selectedTables = items;
           this.drawDiffHeatmap(this.data);
-          events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, items, data, this.scaleFactor);
+          events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, this.selectedTables, this.data, this.scaleFactor);
         });
     });
 
@@ -99,7 +101,10 @@ class DiffHeatMap implements IAppView {
     events.on(AppConstants.EVENT_HIDE_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
 
     // Call the resize function whenever a resize event occurs
-    d3.select(window).on('resize', () => this.drawDiffHeatmap(this.data));
+    d3.select(window).on('resize', () => {
+      this.drawDiffHeatmap(this.data);
+      events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, this.selectedTables, this.data, this.scaleFactor);
+    });
   }
 
   private toggleChangeType(changeType:IChangeType) {

--- a/src/diff_heat_map.ts
+++ b/src/diff_heat_map.ts
@@ -101,8 +101,10 @@ class DiffHeatMap implements IAppView {
     events.on(AppConstants.EVENT_HIDE_CHANGE, (evt, changeType: IChangeType) => this.toggleChangeType(changeType));
 
     events.on(AppConstants.EVENT_RESIZE, () => {
-      this.drawDiffHeatmap(this.data);
-      events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, this.selectedTables, this.data, this.scaleFactor);
+      if(this.data) {
+        this.drawDiffHeatmap(this.data);
+        events.fire(AppConstants.EVENT_DIFF_HEATMAP_LOADED, this.selectedTables, this.data, this.scaleFactor);
+      }
     });
   }
 

--- a/src/heat_map.ts
+++ b/src/heat_map.ts
@@ -6,6 +6,7 @@ import * as vis from 'phovea_core/src/vis';
 import * as events from 'phovea_core/src/event';
 import {IAppView} from './app';
 import * as d3 from 'd3';
+import {AppConstants} from './app_constants';
 
 /**
  * Shows a simple heat map for a given data set.
@@ -15,7 +16,7 @@ class HeatMap implements IAppView {
   private $node;
 
   private heatMapOptions = {
-      initialScale: 5,
+      initialScale: AppConstants.HEATMAP_CELL_SIZE,
       color: ['white', 'black']
     };
 

--- a/src/heat_map.ts
+++ b/src/heat_map.ts
@@ -42,8 +42,15 @@ class HeatMap implements IAppView {
    * Attach event handler for broadcasted events
    */
   private attachListener() {
-    events.on(this.options.eventName, (evt, dataset) => this.update(dataset));
+    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
+      this.clearContent();
+    });
 
+    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, () => {
+      this.clearContent();
+    });
+
+    events.on(this.options.eventName, (evt, dataset) => this.update(dataset));
   }
 
   /**
@@ -69,8 +76,7 @@ class HeatMap implements IAppView {
 
     return Promise.all([plugins[0].load()])
       .then((args) => {
-        // remove the previous heat map
-        this.$node.selectAll('*').remove();
+        this.clearContent();
 
        // console.log('args from plugins', args);
         const plugin = args[0];
@@ -82,6 +88,13 @@ class HeatMap implements IAppView {
         );
         return this;
       });
+  }
+
+  /**
+   * Remove the previous heatmap
+   */
+  private clearContent() {
+    this.$node.selectAll('*').remove();
   }
 
 }

--- a/src/heat_map.ts
+++ b/src/heat_map.ts
@@ -82,7 +82,10 @@ class HeatMap implements IAppView {
       return;
     }
 
-    const options = mixin(this.heatMapOptions, {initialScale: this.heatMapOptions.initialScale * scaleFactor});
+    const options = {
+      initialScale: this.heatMapOptions.initialScale * scaleFactor,
+      color: this.heatMapOptions.color
+    };
 
     return Promise.all([plugins[0].load()])
       .then((args) => {
@@ -104,7 +107,7 @@ class HeatMap implements IAppView {
    * Remove the previous heatmap
    */
   private clearContent() {
-    this.$node.selectAll('*').remove();
+    this.$node.html('');
   }
 
 }

--- a/src/histogram_2d.ts
+++ b/src/histogram_2d.ts
@@ -102,6 +102,10 @@ class Histogram2D implements IAppView {
    * Attach event handler for broadcasted events
    */
   private attachListener() {
+    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
+      this.clearContent();
+    });
+
     events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, items) => {
       if(items.length === 2) {
         this.selectedTables = [items[0].item.desc.id, items[1].item.desc.id];

--- a/src/histogram_2d.ts
+++ b/src/histogram_2d.ts
@@ -40,7 +40,7 @@ class Histogram2D implements IAppView {
   }
 
   private static getJSONHistogram(pair) {
-    const binRows = 10;
+    const binRows = 20;
     const binCols = 20;
     const operations = ChangeTypes.forURL();
     return ajax.getAPIJSON(`/taco/compare/${pair[0]}/${pair[1]}/${binRows}/${binCols}/${operations}/histogram`);
@@ -262,9 +262,7 @@ class Histogram2D implements IAppView {
         return xScale(d.ratios.c_ratio) + 'px';
       })
       .style('height', gridSize - 1 + 'px')
-      .attr('title', function (d) {
-        return ChangeTypes.CONTENT.label + ': ' + Math.round((d.ratios.c_ratio * 100) * 1000) / 1000 + '%';
-      })
+      .attr('title', (d) => `${ChangeTypes.CONTENT.label}: ${Math.round((d.ratios.c_ratio * 100) * 1000) / 1000}% (${d.id})`)
       .style('transform', function (d) {
         return 'translate(' + 0 + 'px,' + yScale(d.pos) + 'px)';
       })
@@ -279,9 +277,7 @@ class Histogram2D implements IAppView {
         return xScale(d.ratios.d_ratio) + 'px';
       })
       .style('height', gridSize - 1 + 'px')
-      .attr('title', function (d) {
-        return ChangeTypes.REMOVED.label + ': ' + Math.round((d.ratios.d_ratio * 100) * 1000) / 1000 + '%';
-      })
+      .attr('title', (d) => `${ChangeTypes.REMOVED.label}: ${Math.round((d.ratios.d_ratio * 100) * 1000) / 1000}% (${d.id})`)
       .style('transform', function (d) {
         const content = xScale(d.ratios.d_ratio);
         // console.log(content);
@@ -305,9 +301,7 @@ class Histogram2D implements IAppView {
         return xScale(d.ratios.a_ratio) + 'px';
       })
       .style('height', gridSize - 1 + 'px')
-      .attr('title', function (d) {
-        return ChangeTypes.ADDED.label + ': ' + Math.round((d.ratios.a_ratio * 100) * 1000) / 1000 + '%';
-      })
+      .attr('title', (d) => `${ChangeTypes.ADDED.label}: ${Math.round((d.ratios.a_ratio * 100) * 1000) / 1000}% (${d.id})`)
       .style('transform', function (d) {
         const structure = xScale(d.ratios.a_ratio);
         //console.log(structure);
@@ -345,9 +339,7 @@ class Histogram2D implements IAppView {
         return xScale(d.ratios.c_ratio) + 'px';
       })
       .style('height', gridSize - 1 + 'px')
-      .attr('title', function (d) {
-        return ChangeTypes.CONTENT.label + ': ' + Math.round((d.ratios.c_ratio * 100) * 1000) / 1000 + '%';
-      })
+      .attr('title', (d) => `${ChangeTypes.CONTENT.label}: ${Math.round((d.ratios.c_ratio * 100) * 1000) / 1000}% (${d.id})`)
       .style('transform', function (d) {
         return 'translate(' + 0 + 'px,' + yScale(d.pos) + 'px)';
       })
@@ -362,9 +354,7 @@ class Histogram2D implements IAppView {
         return xScale(d.ratios.d_ratio) + 'px';
       })
       .style('height', gridSize - 1 + 'px')
-      .attr('title', function (d) {
-        return ChangeTypes.REMOVED.label + ': ' + Math.round((d.ratios.d_ratio * 100) * 1000) / 1000 + '%';
-      })
+      .attr('title', (d) => `${ChangeTypes.REMOVED.label}: ${Math.round((d.ratios.r_ratio * 100) * 1000) / 1000}% (${d.id})`)
       .style('transform', function (d) {
         const content = xScale(d.ratios.d_ratio);
         //console.log(content);
@@ -388,9 +378,7 @@ class Histogram2D implements IAppView {
         return xScale(d.ratios.a_ratio) + 'px';
       })
       .style('height', gridSize - 1 + 'px')
-      .attr('title', function (d) {
-        return ChangeTypes.ADDED.label + ': ' + Math.round((d.ratios.a_ratio * 100) * 1000) / 1000 + '%';
-      })
+      .attr('title', (d) => `${ChangeTypes.ADDED.label}: ${Math.round((d.ratios.a_ratio * 100) * 1000) / 1000}% (${d.id})`)
       .style('transform', function (d) {
         const structure = xScale(d.ratios.a_ratio);
         let acc = 0;

--- a/src/meta_info_box.ts
+++ b/src/meta_info_box.ts
@@ -49,7 +49,7 @@ class MetaInfoBox implements IAppView {
    */
   private attachListener() {
     // Call the resize function whenever a resize event occurs
-    d3.select(window).on('resize', () => this.resize());
+    events.on(AppConstants.EVENT_RESIZE, () => this.resize());
 
     events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
       this.clearContent();

--- a/src/meta_info_box.ts
+++ b/src/meta_info_box.ts
@@ -51,6 +51,10 @@ class MetaInfoBox implements IAppView {
     // Call the resize function whenever a resize event occurs
     d3.select(window).on('resize', () => this.resize());
 
+    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
+      this.clearContent();
+    });
+
     events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, (evt, items) => {
       if(items.length === 2) {
         this.updateItems(items);

--- a/src/reorder_view.ts
+++ b/src/reorder_view.ts
@@ -35,8 +35,6 @@ interface IReorderChange {
 class ReorderView implements IAppView {
 
   private $node;
-  private $srcAxis;
-  private $destAxis;
   private $slopes;
 
   private options = {
@@ -62,13 +60,18 @@ class ReorderView implements IAppView {
   }
 
   private build() {
-
-    this.$srcAxis = this.$node.append('line').classed('src', true);
-    this.$destAxis = this.$node.append('line').classed('dest', true);
     this.$slopes = this.$node.append('g').classed('slopes', true);
   }
 
   private attachListener() {
+    events.on(AppConstants.EVENT_DATA_COLLECTION_SELECTED, () => {
+      this.clearContent();
+    });
+
+    events.on(AppConstants.EVENT_TIME_POINTS_SELECTED, () => {
+      this.clearContent();
+    });
+
     events.on(AppConstants.EVENT_DIFF_HEATMAP_LOADED, (evt, pair, diffData) => {
       if(pair.length === 2) {
         this.draw(pair[0], pair[1], diffData);
@@ -98,18 +101,6 @@ class ReorderView implements IAppView {
   private drawRows(srcSize, dstSize, reorders:IReorderChange[]) {
     const width = this.$node.property('clientWidth')-1;
 
-    /*this.$srcAxis
-      .attr('x1', 0)
-      .attr('x2', 0)
-      .attr('y1', this.scale(0))
-      .attr('y2', this.scale(srcSize));
-
-    this.$destAxis
-      .attr('x1', width)
-      .attr('x2', width)
-      .attr('y1', this.scale(0))
-      .attr('y2', this.scale(dstSize));*/
-
     const $slopes = this.$slopes.selectAll('line').data(reorders, (d) => d.id);
 
     $slopes.enter().append('line');
@@ -122,6 +113,10 @@ class ReorderView implements IAppView {
       .attr('y2', (d) => this.scale(d.to));
 
     $slopes.exit().remove();
+  }
+
+  private clearContent() {
+    this.$slopes.selectAll('*').remove();
   }
 
 }

--- a/src/reorder_view.ts
+++ b/src/reorder_view.ts
@@ -83,7 +83,8 @@ class ReorderView implements IAppView {
     switch (this.options.orientation) {
       case EOrientation.COLUMN:
         this.scale.domain([0, Math.max(src.desc.size[1], dst.desc.size[1])]);
-        this.drawRows(diffData.reorder.cols, scaleFactor);
+        this.scale.range([0, Math.max(src.desc.size[1], dst.desc.size[1]) * AppConstants.HEATMAP_CELL_SIZE * scaleFactor]);
+        this.drawColumns(diffData.reorder.cols, scaleFactor);
         break;
 
       case EOrientation.ROW:
@@ -111,7 +112,7 @@ class ReorderView implements IAppView {
       .transition()
       .attr('x1', 0)
       .attr('x2', width)
-      .attr('title', (d) => `${d.id}: ${d.diff}`)
+      .attr('title', (d) => `${d.id}: ${d.diff} (src: ${d.from}, dest: ${d.to})`)
       .attr('y1', (d) => this.scale(d.from) - (AppConstants.HEATMAP_CELL_SIZE * scaleFactor * 0.5))
       .attr('y2', (d) => this.scale(d.to) - (AppConstants.HEATMAP_CELL_SIZE * scaleFactor * 0.5));
 

--- a/src/reorder_view.ts
+++ b/src/reorder_view.ts
@@ -1,0 +1,138 @@
+/**
+ * Created by Holger Stitz on 22.03.2017.
+ */
+
+import {IAppView} from './app';
+import * as d3 from 'd3';
+import * as events from 'phovea_core/src/event';
+import {AppConstants} from './app_constants';
+import {mixin} from 'phovea_core/src';
+
+export enum EOrientation {
+  COLUMN,
+  ROW
+}
+
+interface IReorderChange {
+  /**
+   * Row or column ID
+   */
+  id: string;
+  /**
+   * Difference between from and to
+   */
+  diff: number;
+  /**
+   * Position index in source table
+   */
+  from: number;
+  /**
+   * Position index in destination table
+   */
+  to: number;
+}
+
+class ReorderView implements IAppView {
+
+  private $node;
+  private $srcAxis;
+  private $destAxis;
+  private $slopes;
+
+  private options = {
+    orientation: EOrientation.ROW
+  };
+
+  private scale = d3.scale.linear().range([0, 200]);
+
+  constructor(public parent:Element, options:any) {
+    this.options = mixin(this.options, options);
+
+    this.$node = d3.select(parent)
+      .append('svg')
+      .classed('reorderView', true);
+  }
+
+  init() {
+    this.build();
+    this.attachListener();
+
+    // return the promise directly as long there is no dynamical data to update
+    return Promise.resolve(this);
+  }
+
+  private build() {
+
+    this.$srcAxis = this.$node.append('line').classed('src', true);
+    this.$destAxis = this.$node.append('line').classed('dest', true);
+    this.$slopes = this.$node.append('g').classed('slopes', true);
+  }
+
+  private attachListener() {
+    events.on(AppConstants.EVENT_DIFF_HEATMAP_LOADED, (evt, pair, diffData) => {
+      if(pair.length === 2) {
+        this.draw(pair[0], pair[1], diffData);
+      }
+    });
+  }
+
+  private draw(src, dst, diffData) {
+    console.log(src, dst);
+    switch (this.options.orientation) {
+      case EOrientation.COLUMN:
+        this.scale.domain([0, Math.max(src.desc.size[1], dst.desc.size[1])]);
+        this.drawRows(src.desc.size[1], dst.desc.size[1], diffData.reorder.cols);
+        break;
+
+      case EOrientation.ROW:
+        this.scale.domain([0, Math.max(src.desc.size[0], dst.desc.size[0])]);
+        this.drawRows(src.desc.size[0], dst.desc.size[0], diffData.reorder.rows);
+        break;
+    }
+  }
+
+  private drawColumns(srcSize, dstSize, reorders:IReorderChange[]) {
+    //
+  }
+
+  private drawRows(srcSize, dstSize, reorders:IReorderChange[]) {
+    const width = this.$node.property('clientWidth')-1;
+
+    /*this.$srcAxis
+      .attr('x1', 0)
+      .attr('x2', 0)
+      .attr('y1', this.scale(0))
+      .attr('y2', this.scale(srcSize));
+
+    this.$destAxis
+      .attr('x1', width)
+      .attr('x2', width)
+      .attr('y1', this.scale(0))
+      .attr('y2', this.scale(dstSize));*/
+
+    const $slopes = this.$slopes.selectAll('line').data(reorders, (d) => d.id);
+
+    $slopes.enter().append('line');
+
+    $slopes
+      .transition()
+      .attr('x1', 0)
+      .attr('x2', width)
+      .attr('y1', (d) => this.scale(d.from))
+      .attr('y2', (d) => this.scale(d.to));
+
+    $slopes.exit().remove();
+  }
+
+}
+
+
+/**
+ * Factory method to create a new ReorderView instance
+ * @param parent
+ * @param options
+ * @returns {ReorderView}
+ */
+export function create(parent:Element, options:any) {
+  return new ReorderView(parent, options);
+}

--- a/src/reorder_view.ts
+++ b/src/reorder_view.ts
@@ -72,33 +72,32 @@ class ReorderView implements IAppView {
       this.clearContent();
     });
 
-    events.on(AppConstants.EVENT_DIFF_HEATMAP_LOADED, (evt, pair, diffData) => {
+    events.on(AppConstants.EVENT_DIFF_HEATMAP_LOADED, (evt, pair, diffData, scaleFactor:number) => {
       if(pair.length === 2) {
-        this.draw(pair[0], pair[1], diffData);
+        this.draw(pair[0], pair[1], diffData, scaleFactor);
       }
     });
   }
 
-  private draw(src, dst, diffData) {
-    console.log(src, dst);
+  private draw(src, dst, diffData, scaleFactor:number) {
     switch (this.options.orientation) {
       case EOrientation.COLUMN:
         this.scale.domain([0, Math.max(src.desc.size[1], dst.desc.size[1])]);
-        this.drawRows(src.desc.size[1], dst.desc.size[1], diffData.reorder.cols);
+        this.drawRows(diffData.reorder.cols, scaleFactor);
         break;
 
       case EOrientation.ROW:
-        this.scale.domain([0, Math.max(src.desc.size[0], dst.desc.size[0])]);
-        this.drawRows(src.desc.size[0], dst.desc.size[0], diffData.reorder.rows);
+        this.scale.domain([0, Math.max(src.desc.size[0], dst.desc.size[0]) * scaleFactor]);
+        this.drawRows(diffData.reorder.rows, scaleFactor);
         break;
     }
   }
 
-  private drawColumns(srcSize, dstSize, reorders:IReorderChange[]) {
+  private drawColumns(reorders:IReorderChange[], scaleFactor:number) {
     //
   }
 
-  private drawRows(srcSize, dstSize, reorders:IReorderChange[]) {
+  private drawRows(reorders:IReorderChange[], scaleFactor:number) {
     const width = this.$node.property('clientWidth')-1;
 
     const $slopes = this.$slopes.selectAll('line').data(reorders, (d) => d.id);

--- a/src/reorder_view.ts
+++ b/src/reorder_view.ts
@@ -87,7 +87,8 @@ class ReorderView implements IAppView {
         break;
 
       case EOrientation.ROW:
-        this.scale.domain([0, Math.max(src.desc.size[0], dst.desc.size[0]) * scaleFactor]);
+        this.scale.domain([0, Math.max(src.desc.size[0], dst.desc.size[0])]);
+        this.scale.range([0, Math.max(src.desc.size[0], dst.desc.size[0]) * AppConstants.HEATMAP_CELL_SIZE * scaleFactor]);
         this.drawRows(diffData.reorder.rows, scaleFactor);
         break;
     }
@@ -98,6 +99,8 @@ class ReorderView implements IAppView {
   }
 
   private drawRows(reorders:IReorderChange[], scaleFactor:number) {
+
+    this.$node.attr('height', this.scale.range()[1]);
     const width = this.$node.property('clientWidth')-1;
 
     const $slopes = this.$slopes.selectAll('line').data(reorders, (d) => d.id);
@@ -108,8 +111,9 @@ class ReorderView implements IAppView {
       .transition()
       .attr('x1', 0)
       .attr('x2', width)
-      .attr('y1', (d) => this.scale(d.from))
-      .attr('y2', (d) => this.scale(d.to));
+      .attr('title', (d) => `${d.id}: ${d.diff}`)
+      .attr('y1', (d) => this.scale(d.from) - (AppConstants.HEATMAP_CELL_SIZE * scaleFactor * 0.5))
+      .attr('y2', (d) => this.scale(d.to) - (AppConstants.HEATMAP_CELL_SIZE * scaleFactor * 0.5));
 
     $slopes.exit().remove();
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -63,7 +63,7 @@ $app-margin-top: 50;
   align-content: stretch;
   justify-content: space-between;
 
-  &>div{
+  & > div{
     width: 33%;
   }
 
@@ -75,8 +75,9 @@ $app-margin-top: 50;
 .taco-table {
   position: relative;
   border: 1px solid black;
+  margin: 0 50px;
 
-  &>div {
+  & > div {
     position: absolute;
   }
 }
@@ -456,5 +457,24 @@ select.form-control {
   button {
     position: relative;
     left: -35px;
+  }
+}
+
+.diffheatmap {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.reorderView {
+  position: absolute;
+  width: 100%;
+
+  line {
+    fill: none;
+    stroke: darken($reorder-color, 30%);
+  }
+  & > line {
+    shape-rendering: crispEdges;
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -56,32 +56,6 @@ $app-margin-top: 50;
   margin: $app-margin-top+px 20px 20px;
 }
 
-.comparison {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  align-content: stretch;
-  justify-content: space-between;
-
-  & > div{
-    width: 33%;
-  }
-
-  .heatmap:first-child {
-    text-align: right;
-  }
-}
-
-.taco-table {
-  position: relative;
-  border: 1px solid black;
-  margin: 0 50px;
-
-  & > div {
-    position: absolute;
-  }
-}
-
 #caleydoHeader {
   position: fixed;
   z-index: 100000;
@@ -460,10 +434,38 @@ select.form-control {
   }
 }
 
+.comparison {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  align-content: stretch;
+  justify-content: space-between;
+
+  .heatmap {
+    width: 33%;
+  }
+
+  .heatmap:first-child {
+    text-align: right;
+  }
+}
+
 .diffheatmap {
   position: relative;
   display: flex;
   justify-content: center;
+  width: calc(33% + 100px);
+}
+
+.taco-table {
+  position: relative;
+  border: 1px solid black;
+  margin: 0 50px;
+  width: calc(100% - 100px);
+
+  & > div {
+    position: absolute;
+  }
 }
 
 .reorderView {

--- a/src/style.scss
+++ b/src/style.scss
@@ -14,6 +14,7 @@ $boostrapAssetDir: '~phovea_ui/src/assets';
 body, html {
   font-family: Yantramanav, 'Helvetica Neue', Helvetica, sans-serif !important;
   font-weight: 400 !important;
+  height: auto !important;
 }
 
 h1,h2,h3,h4,h5,h6 {
@@ -245,6 +246,7 @@ button:active, button.active {
 
   .histogram_2d {
     order: 2;
+    width: calc(33% + 100px);
     text-align: center;
   }
 
@@ -462,8 +464,9 @@ select.form-control {
   border: 1px solid black;
   margin: 0 50px;
   width: calc(100% - 100px);
+  background: white;
 
-  & > div {
+  & div.transform > div {
     position: absolute;
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -423,6 +423,8 @@ select.form-control {
 
   .bar {
     transition: height ease 0.2s;
+    display: flex;
+    flex-direction: column-reverse;
   }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -478,8 +478,10 @@ select.form-control {
   line {
     fill: none;
     stroke: darken($reorder-color, 30%);
-  }
-  & > line {
-    shape-rendering: crispEdges;
+    stroke-width: 2;
+
+    &:hover {
+      stroke: $select-color;
+    }
   }
 }

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -2,7 +2,6 @@
  * Created by Holger Stitz on 29.08.2016.
  */
 
-import * as moment from 'moment';
 import * as d3 from 'd3';
 import * as $ from 'jquery';
 import * as events from 'phovea_core/src/event';
@@ -72,8 +71,7 @@ class Timeline implements IAppView {
         .forEach((d) => d.classed('active', true)); // add .active class
     });
 
-    // Call the resize function whenever a resize event occurs
-    d3.select(window).on('resize', () => this.resize());
+    events.on(AppConstants.EVENT_RESIZE, () => this.resize());
   }
 
   /**

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -126,7 +126,7 @@ class Timeline implements IAppView {
     // Append the circles and add the mouseover and click listeners
     $xAxis.selectAll('.tick text')
       .on('click', function (date:Date) {
-        const found = that.items.filter((item) => item.time.isSame(date, 'year'));
+        const found = that.items.filter((item) => item.time.isSame(date, item.timeFormat.momentIsSame));
         const d = found[0];
         (<MouseEvent>d3.event).preventDefault();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,6 +6,7 @@ import * as moment from 'moment';
 import * as d3 from 'd3';
 import * as events from 'phovea_core/src/event';
 import {AppConstants} from './app_constants';
+import {hash} from 'phovea_core/src';
 
 
 export function getPosXScale(items, totalWidth, padding = 20) {
@@ -51,10 +52,41 @@ export function selectTimePoint(timepoint) {
   // sort elements by time -> [0] = earlier = source; [1] = later = destination
   selectedTimePoints = selectedTimePoints.sort((a, b) => d3.ascending(a.time, b.time));
 
+  hash.setProp(AppConstants.HASH_PROPS.TIME_POINTS, selectedTimePoints.map((d) => d.key).join(','));
+
+  if(selectedTimePoints.length === 1) {
+    hash.removeProp(AppConstants.HASH_PROPS.DETAIL_VIEW); // remove detail view prop
+  }
+
   events.fire(AppConstants.EVENT_TIME_POINTS_SELECTED, selectedTimePoints);
 
   // clear after 2 selected time points
   if(selectedTimePoints.length === 2) {
     selectedTimePoints = [];
+  }
+}
+
+/**
+ * Filters list of time points from given keys in the URL hash and fires the event
+ * @param timepoints
+ */
+export function selectTimePointFromHash(timepoints) {
+  if(hash.has(AppConstants.HASH_PROPS.TIME_POINTS) === false) {
+    return;
+  }
+
+  const selectedTPKeys:string[] = hash.getProp(AppConstants.HASH_PROPS.TIME_POINTS).split(',');
+  const selectedTimePoints = timepoints.filter((d) => selectedTPKeys.indexOf(d.key) > -1);
+
+  selectedTimePoints.forEach((d) => {
+    selectTimePoint(d);
+  });
+
+  if(selectedTimePoints.length === 2 && hash.getInt(AppConstants.HASH_PROPS.DETAIL_VIEW) === 1) {
+    events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, selectedTimePoints[0].item);
+    events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, selectedTimePoints[1].item);
+    events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, selectedTimePoints.map((d) => d.item));
+  } else {
+    hash.removeProp(AppConstants.HASH_PROPS.DETAIL_VIEW);
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,16 +43,16 @@ let selectedTimePoints = [];
 /**
  * Stores a selected time point and sends an event with all stored time points
  * If two time points are stored, the array is cleared
- *
- * @param timepoint
+ * @param timepoints
  */
-export function selectTimePoint(timepoint) {
-  selectedTimePoints.push(timepoint);
+export function selectTimePoint(...timepoints) {
+  selectedTimePoints.push(...timepoints);
 
   // sort elements by time -> [0] = earlier = source; [1] = later = destination
   selectedTimePoints = selectedTimePoints.sort((a, b) => d3.ascending(a.time, b.time));
 
   hash.setProp(AppConstants.HASH_PROPS.TIME_POINTS, selectedTimePoints.map((d) => d.key).join(','));
+  hash.removeProp(AppConstants.HASH_PROPS.DETAIL_VIEW);
 
   events.fire(AppConstants.EVENT_TIME_POINTS_SELECTED, selectedTimePoints);
 
@@ -73,15 +73,14 @@ export function selectTimePointFromHash(timepoints) {
 
   const selectedTPKeys:string[] = hash.getProp(AppConstants.HASH_PROPS.TIME_POINTS).split(',');
   const selectedTimePoints = timepoints.filter((d) => selectedTPKeys.indexOf(d.key) > -1);
+  const showDetailView = hash.getInt(AppConstants.HASH_PROPS.DETAIL_VIEW);
 
-  selectedTimePoints.forEach((d) => {
-    selectTimePoint(d);
-  });
+  selectTimePoint(...selectedTimePoints);
 
-  if(selectedTimePoints.length === 2 && hash.getInt(AppConstants.HASH_PROPS.DETAIL_VIEW) === 1) {
-    events.fire(AppConstants.EVENT_DATASET_SELECTED_LEFT, selectedTimePoints[0].item);
-    events.fire(AppConstants.EVENT_DATASET_SELECTED_RIGHT, selectedTimePoints[1].item);
-    events.fire(AppConstants.EVENT_OPEN_DIFF_HEATMAP, selectedTimePoints.map((d) => d.item));
+  if(selectedTimePoints.length === 2 && showDetailView === 1) {
+    hash.setInt(AppConstants.HASH_PROPS.DETAIL_VIEW, showDetailView);
+    events.fire(AppConstants.EVENT_OPEN_DETAIL_VIEW, selectedTimePoints);
+
   } else {
     hash.removeProp(AppConstants.HASH_PROPS.DETAIL_VIEW);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,10 +54,6 @@ export function selectTimePoint(timepoint) {
 
   hash.setProp(AppConstants.HASH_PROPS.TIME_POINTS, selectedTimePoints.map((d) => d.key).join(','));
 
-  if(selectedTimePoints.length === 1) {
-    hash.removeProp(AppConstants.HASH_PROPS.DETAIL_VIEW); // remove detail view prop
-  }
-
   events.fire(AppConstants.EVENT_TIME_POINTS_SELECTED, selectedTimePoints);
 
   // clear after 2 selected time points

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,16 +28,6 @@ export function getTimeScale(items, totalWidth, padding = 20) {
     .range([padding, totalWidth - padding]);
 }
 
-
-export function scaleCircles(totalwidth, numberofCircles) {
-  //Bigger value means more compressed points on the time line
-  const padding = 80;
-  //showing only 7 circles on the timeline when no time-object is availiable for the specific dataset
-  // in the next step -> implement the feature of a scroll bar showing more data points on the timeline
-  // const numberofCircles = 7;
-  return (totalwidth - padding) / numberofCircles;
-}
-
 let selectedTimePoints = [];
 
 /**


### PR DESCRIPTION
A few things are gathered in this PR:

* Reorder view (#52)
* Show reorder as part of content changes in bar chart
* Improved scaling of heatmaps
* Fixed resizing of all views (#82, #84)
* Restore current state from URL hash

![taggle_mixed](https://cloud.githubusercontent.com/assets/5851088/24308013/9bf90974-10c6-11e7-9879-69296547a5a4.gif)

