### PR TITLE
Upgrade to Font Awesome v5 (Free)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "jquery-ui": "1.12.1",
     "moment": "~2.24.0",
-    "phovea_ui": "github:phovea/phovea_ui#dmoitzi/refactor_stylesheets_organiation_and_imports",
-    "phovea_vis": "github:phovea/phovea_vis#dmoitzi/refactor_stylesheets_organiation_and_imports"
+    "phovea_ui": "github:phovea/phovea_ui#fontawesome-v5",
+    "phovea_vis": "github:phovea/phovea_vis#fontawesome-v5"
   }
 }


### PR DESCRIPTION
Closes #154 

Tested with the following _workspace.scss_:
```
@debug('import plugin scss variables');
@import "~taco/dist/scss/abstracts/variables";
@import "~phovea_vis/dist/scss/abstracts/variables";
@import "~phovea_ui/dist/scss/abstracts/variables";

@debug('import plugin main scss');
@import "~phovea_ui/dist/scss/main";
@import "~phovea_vis/dist/scss/main";
@import "~taco/dist/scss/main";
```